### PR TITLE
AB#148532 Only show the Incomplete Inspection Justification in the Settings tab…

### DIFF
--- a/TSIS2.WebResources/Webresources/js/WorkOrder.js
+++ b/TSIS2.WebResources/Webresources/js/WorkOrder.js
@@ -1027,14 +1027,19 @@ var ROM;
             }
         }
         function setCantCompleteinspectionVisibility(form) {
+            var systemStatus = form.getAttribute("msdyn_systemstatus").getValue();
             var plannedFiscalQuarter = form.getAttribute("ovs_fiscalquarter").getValue();
+            var validWorkOrderStatus = false;
+            if (systemStatus != null && (systemStatus == 690970000 /* Unscheduled */ || systemStatus == 690970001 /* Scheduled */ || systemStatus == 690970002 /* InProgress */)) {
+                validWorkOrderStatus = true;
+            }
             if (plannedFiscalQuarter != null) {
                 //fetch the end date of the Planned Fiscal Quarter
                 Xrm.WebApi.retrieveRecord("tc_tcfiscalquarter", plannedFiscalQuarter[0].id.replace(/({|})/g, ''), "?$select=tc_quarterend").then(function success(result) {
                     var currentDateTime = new Date();
                     var quarterendDate = new Date(result.tc_quarterend);
-                    //if we are past the end date of the quarter, make the Can't Complete Inspection visible, otherwise hide it
-                    if (quarterendDate < currentDateTime) {
+                    //if we are past the end date of the quarter and have a valid work order status, make the Can't Complete Inspection visible, otherwise hide it
+                    if (quarterendDate < currentDateTime && validWorkOrderStatus) {
                         setCantCompleteInspectionControlsVisibility(form, true);
                     }
                     else {

--- a/TSIS2.WebResources/src/ts/WorkOrder.ts
+++ b/TSIS2.WebResources/src/ts/WorkOrder.ts
@@ -1134,7 +1134,13 @@ namespace ROM.WorkOrder {
     }
 
     function setCantCompleteinspectionVisibility(form: Form.msdyn_workorder.Main.ROMOversightActivity): void {
+        const systemStatus = form.getAttribute("msdyn_systemstatus").getValue();
         let plannedFiscalQuarter = form.getAttribute("ovs_fiscalquarter").getValue();
+        let validWorkOrderStatus = false;
+
+        if (systemStatus != null && (systemStatus == msdyn_wosystemstatus.Unscheduled || systemStatus == msdyn_wosystemstatus.Scheduled || systemStatus == msdyn_wosystemstatus.InProgress)) {
+            validWorkOrderStatus = true;
+        }
 
         if (plannedFiscalQuarter != null) {
 
@@ -1146,8 +1152,8 @@ namespace ROM.WorkOrder {
 
                     let quarterendDate = new Date(result.tc_quarterend);
 
-                    //if we are past the end date of the quarter, make the Can't Complete Inspection visible, otherwise hide it
-                    if (quarterendDate < currentDateTime) {
+                    //if we are past the end date of the quarter and have a valid work order status, make the Can't Complete Inspection visible, otherwise hide it
+                    if (quarterendDate < currentDateTime && validWorkOrderStatus) {
                         setCantCompleteInspectionControlsVisibility(form, true);
                     }
                     else {


### PR DESCRIPTION
… of a WO if the Record status is Unscheduled, Scheduled, and InProgress and the current date is past the planned fiscal quarter.